### PR TITLE
Fix python compilation 

### DIFF
--- a/pir/parser/pir.g4
+++ b/pir/parser/pir.g4
@@ -56,7 +56,7 @@ floatType: 'Float';
 charType: 'Char';
 
 numberType: integerType | floatType;
-type: booleanType | integerType | floatType | charType;
+genericType: booleanType | integerType | floatType | charType;
 
 // Functions
 
@@ -80,7 +80,7 @@ simpleClassDeclaration:
 completeClassDeclaration:
 	simpleClassDeclaration '{' generalDeclaration* '}';
 
-typeDeclaration: Identifier ':' type;
+typeDeclaration: Identifier ':' genericType;
 
 generalDeclaration:
 	generalAssignment

--- a/pir/parser/pir.g4
+++ b/pir/parser/pir.g4
@@ -203,7 +203,7 @@ generalAssignment:
 
 baseParameter: Identifier | IntegerLiteral | FloatLiteral;
 
-NewLine: '\n';
+NewLine: '\n' -> skip;
 ClassIdentifier: [A-Z][a-zA-Z]*;
 Identifier: [a-zA-Z0-9]+;
 Comment: '#' ~[\r\n]* -> skip;


### PR DESCRIPTION
## Description 

- Replace `type` with `genericType` to support phyton compilation
- Ignore empty lines. e.g. `\n`